### PR TITLE
Switch manpukun icon to puku.png

### DIFF
--- a/app/recommend/page.tsx
+++ b/app/recommend/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Heart, ArrowLeft } from 'lucide-react';
+import Image from 'next/image';
 import UserForm from '@/components/recommend/UserForm';
 import ManpukunChat from '@/components/recommend/ManpukunChat';
 import { RecommendationRequest, RecommendationResult, APIResponse } from '@/types';
@@ -54,8 +55,13 @@ export default function RecommendPage() {
           <div className="py-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-3">
-                <div className="w-10 h-10 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center shadow-lg">
-                  <span className="text-xl">🍙</span>
+                <div className="w-10 h-10 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center shadow-lg overflow-hidden">
+                  <Image
+                    src="/manpukun/puku.png"
+                    alt="まんぷくん"
+                    width={40}
+                    height={40}
+                  />
                 </div>
                 <div>
                   <h1 className="text-xl font-bold text-gray-900">
@@ -86,8 +92,13 @@ export default function RecommendPage() {
           /* 入力フォーム画面 */
           <div className="max-w-2xl mx-auto">
             <div className="text-center mb-8">
-              <div className="w-20 h-20 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center mx-auto mb-4 shadow-lg">
-                <span className="text-3xl">🍙</span>
+              <div className="w-20 h-20 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center mx-auto mb-4 shadow-lg overflow-hidden">
+                <Image
+                  src="/manpukun/puku.png"
+                  alt="まんぷくん"
+                  width={80}
+                  height={80}
+                />
               </div>
               <h2 className="text-2xl font-bold text-gray-900 mb-2">
                 こんにちは！まんぷくんです
@@ -152,8 +163,13 @@ export default function RecommendPage() {
               {error && (
                 <div className="mt-6 bg-red-50 border border-red-200 rounded-xl p-6">
                   <div className="flex items-center space-x-3">
-                    <div className="w-10 h-10 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center">
-                      <span className="text-sm">🍙</span>
+                  <div className="w-10 h-10 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center overflow-hidden">
+                      <Image
+                        src="/manpukun/puku.png"
+                        alt="まんぷくん"
+                        width={40}
+                        height={40}
+                      />
                     </div>
                     <div>
                       <h4 className="font-semibold text-red-800 mb-1">

--- a/components/recommend/ManpukunChat.tsx
+++ b/components/recommend/ManpukunChat.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { RecommendationResult, ManpukunExpression } from '@/types';
 import { Star, ExternalLink, Gift, Clock, Truck } from 'lucide-react';
+import Image from 'next/image';
 
 interface ManpukunChatProps {
   recommendations?: RecommendationResult[];
@@ -88,9 +89,13 @@ export default function ManpukunChat({ recommendations, loading }: ManpukunChatP
       {/* まんぷくんのアバター */}
       <div className="flex items-center space-x-4 mb-6">
         <div className="relative">
-          <div className="w-16 h-16 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center shadow-lg">
-            {/* 実際の実装では画像を使用 */}
-            <span className="text-2xl">🍙</span>
+          <div className="w-16 h-16 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center shadow-lg overflow-hidden">
+            <Image
+              src="/manpukun/puku.png"
+              alt="まんぷくん"
+              width={64}
+              height={64}
+            />
           </div>
           {loading && (
             <div className="absolute -top-1 -right-1 w-4 h-4 bg-green-500 rounded-full animate-pulse"></div>
@@ -106,8 +111,13 @@ export default function ManpukunChat({ recommendations, loading }: ManpukunChatP
       <div className="space-y-6">
         {messages.map((message) => (
           <div key={message.id} className="flex space-x-3">
-            <div className="w-10 h-10 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center flex-shrink-0">
-              <span className="text-sm">🍙</span>
+            <div className="w-10 h-10 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden">
+              <Image
+                src="/manpukun/puku.png"
+                alt="まんぷくん"
+                width={40}
+                height={40}
+              />
             </div>
             <div className="flex-1">
               <div className="bg-white rounded-2xl rounded-tl-sm p-4 shadow-sm border">
@@ -228,8 +238,13 @@ export default function ManpukunChat({ recommendations, loading }: ManpukunChatP
         {/* ローディング表示 */}
         {loading && (
           <div className="flex space-x-3">
-            <div className="w-10 h-10 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center flex-shrink-0">
-              <span className="text-sm">🍙</span>
+            <div className="w-10 h-10 bg-gradient-to-br from-orange-400 to-red-500 rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden">
+              <Image
+                src="/manpukun/puku.png"
+                alt="まんぷくん"
+                width={40}
+                height={40}
+              />
             </div>
             <div className="bg-white rounded-2xl rounded-tl-sm p-4 shadow-sm border">
               <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary
- import `Image` from `next/image`
- show `/manpukun/puku.png` image instead of the onigiri emoji

## Testing
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6889c8f747388326913d4bd53ffeabd8