### PR TITLE
Allow large CSV uploads

### DIFF
--- a/app/api/upload-csv/route.ts
+++ b/app/api/upload-csv/route.ts
@@ -3,6 +3,18 @@ import { createClient } from '@supabase/supabase-js';
 import Papa from 'papaparse';
 import { CSVRowData, ReturnGift, APIResponse } from '@/types';
 
+// Allow large CSV uploads (up to 1GB)
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '1024mb',
+    },
+  },
+};
+
+// Ensure this route runs in the Node.js runtime
+export const runtime = 'nodejs';
+
 const getSupabase = () =>
   createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
## Summary
- support big CSV upload by configuring body size limit

## Testing
- `CI=true npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6889f865ab0c8326ad7768bd8cda9b79