### PR TITLE
Add CSV import script from Supabase Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,20 @@ manpuku-recommend/
 
 その他のカラムについては `types/index.ts` を参照してください。
 
+### 大きなCSVデータのインポート
+
+大量データを一度に登録する場合は、CSVファイルを Supabase Storage にアップロードしてから
+サーバースクリプトを実行します。
+
+1. [Supabase コンソール](https://app.supabase.com/) で任意のバケットを作成し、CSV ファイルをアップロードします。
+2. 環境変数 `NEXT_PUBLIC_SUPABASE_URL` と `SUPABASE_SERVICE_ROLE_KEY` を設定した状態で、次のコマンドを実行します。
+
+```bash
+npx ts-node scripts/import-csv-from-storage.ts <bucket名> <ファイルパス>
+```
+
+アップロードしたファイルをダウンロードして `return_gifts` テーブルへ一括登録します。処理が完了すると `csv_uploads` テーブルにも履歴が記録されます。
+
 ## 🚀 デプロイ
 
 ### Vercel デプロイ

--- a/scripts/import-csv-from-storage.ts
+++ b/scripts/import-csv-from-storage.ts
@@ -1,0 +1,80 @@
+import { createAdminClient } from '../lib/supabase';
+import Papa from 'papaparse';
+import { CSVRowData, ReturnGift } from '../types';
+
+function transformCSVToReturnGift(csvRow: CSVRowData): Partial<ReturnGift> {
+  return {
+    gift_id: csvRow.返礼品ID,
+    name: csvRow.返礼品名,
+    description: csvRow.返礼品説明 || '',
+    start_date: csvRow.提供開始日時 ? new Date(csvRow.提供開始日時).toISOString() : undefined,
+    end_date: csvRow.提供終了日時 ? new Date(csvRow.提供終了日時).toISOString() : undefined,
+    donation_amount: parseInt(csvRow.寄付金額) || 0,
+    stock_quantity: csvRow.在庫数 ? parseFloat(csvRow.在庫数) : undefined,
+    capacity_weight: csvRow['容量・重さ'] || '',
+    provider_info: csvRow.提供企業情報 || '',
+    shipping_estimate: csvRow.発送目安 || '',
+    notes: csvRow.注意事項 || '',
+    is_public: csvRow.公開フラグ === '1',
+    temp_shipping: csvRow.常温配送対応フラグ === '1',
+    cold_shipping: csvRow.冷蔵配送対応フラグ === '1',
+    frozen_shipping: csvRow.冷凍配送対応フラグ === '1',
+    regular_delivery: csvRow.定期配送対応フラグ === '1',
+    date_specified_delivery: csvRow.日付指定配送対応フラグ === '1',
+    split_delivery: csvRow.分割配送対応フラグ === '1',
+    simple_packaging: csvRow.簡易包装フラグ === '1',
+    noshi_support: csvRow.のし対応フラグ === '1',
+    municipality_code: csvRow.自治体管理番号 || '',
+    expiry_storage: csvRow['賞味期限・保存'] || '',
+    allergens: csvRow.アレルギー || '',
+    allergen_notes: csvRow.アレルギー備考 || '',
+    category: csvRow.カテゴリ || '',
+    linked_service: csvRow.連携サービス || ''
+  };
+}
+
+async function main() {
+  const bucket = process.argv[2];
+  const filePath = process.argv[3];
+
+  if (!bucket || !filePath) {
+    console.error('Usage: ts-node scripts/import-csv-from-storage.ts <bucket> <path>');
+    process.exit(1);
+  }
+
+  const supabase = createAdminClient();
+
+  const { data: file, error } = await supabase.storage.from(bucket).download(filePath);
+  if (error || !file) {
+    throw new Error(`Failed to download file: ${error?.message}`);
+  }
+
+  const text = await file.text();
+  const parseResult = Papa.parse<CSVRowData>(text, { header: true, skipEmptyLines: true, dynamicTyping: false });
+
+  if (parseResult.errors.length > 0) {
+    throw new Error(parseResult.errors[0].message);
+  }
+
+  const records = parseResult.data.filter(r => r.返礼品ID && r.返礼品名).map(transformCSVToReturnGift);
+
+  // remove existing rows
+  const { error: delErr } = await supabase.from('return_gifts').delete().neq('id', 0);
+  if (delErr) throw delErr;
+
+  const chunkSize = 1000;
+  for (let i = 0; i < records.length; i += chunkSize) {
+    const chunk = records.slice(i, i + chunkSize);
+    const { error: insErr } = await supabase.from('return_gifts').insert(chunk);
+    if (insErr) throw insErr;
+  }
+
+  await supabase.from('csv_uploads').insert({ filename: filePath, record_count: records.length, status: 'completed' });
+
+  console.log(`Imported ${records.length} records from ${filePath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `import-csv-from-storage.ts` script for large data imports
- document how to use the script in README

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6889f5edab688326b0bdc57d3d50207e