### PR TITLE
Enable large CSV upload to Supabase

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lucide-react": "^0.294.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
-    "tailwind-merge": "^2.0.0"
+    "tailwind-merge": "^2.0.0",
+    "busboy": "^1.6.0"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- parse multipart uploads using busboy
- stream CSV rows to Supabase in batches
- allow long processing time for the API route
- add busboy dependency

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6889fba19e2c832695a377bc419b4bf7