### PR TITLE
Enable large CSV uploads via chunked processing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/app/api/upload-csv/route.ts
+++ b/app/api/upload-csv/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import Papa from 'papaparse';
 import { Readable } from 'stream';
 import { CSVRowData, ReturnGift, APIResponse } from '@/types';
+import { transformCSVToReturnGift } from '@/lib/transform';
 
 // Allow large CSV uploads (up to 1GB)
 export const runtime = 'nodejs';
@@ -13,41 +14,46 @@ const getSupabase = () =>
     process.env.SUPABASE_SERVICE_ROLE_KEY!
   );
 
-// CSVの生データをSupabase用のデータに変換
-function transformCSVToReturnGift(csvRow: CSVRowData): Partial<ReturnGift> {
-  return {
-    gift_id: csvRow.返礼品ID,
-    name: csvRow.返礼品名,
-    description: csvRow.返礼品説明 || '',
-    start_date: csvRow.提供開始日時 ? new Date(csvRow.提供開始日時).toISOString() : undefined,
-    end_date: csvRow.提供終了日時 ? new Date(csvRow.提供終了日時).toISOString() : undefined,
-    donation_amount: parseInt(csvRow.寄付金額) || 0,
-    stock_quantity: csvRow.在庫数 ? parseFloat(csvRow.在庫数) : undefined,
-    capacity_weight: csvRow['容量・重さ'] || '',
-    provider_info: csvRow.提供企業情報 || '',
-    shipping_estimate: csvRow.発送目安 || '',
-    notes: csvRow.注意事項 || '',
-    is_public: csvRow.公開フラグ === '1',
-    temp_shipping: csvRow.常温配送対応フラグ === '1',
-    cold_shipping: csvRow.冷蔵配送対応フラグ === '1',
-    frozen_shipping: csvRow.冷凍配送対応フラグ === '1',
-    regular_delivery: csvRow.定期配送対応フラグ === '1',
-    date_specified_delivery: csvRow.日付指定配送対応フラグ === '1',
-    split_delivery: csvRow.分割配送対応フラグ === '1',
-    simple_packaging: csvRow.簡易包装フラグ === '1',
-    noshi_support: csvRow.のし対応フラグ === '1',
-    municipality_code: csvRow.自治体管理番号 || '',
-    expiry_storage: csvRow['賞味期限・保存'] || '',
-    allergens: csvRow.アレルギー || '',
-    allergen_notes: csvRow.アレルギー備考 || '',
-    category: csvRow.カテゴリ || '',
-    linked_service: csvRow.連携サービス || ''
-  };
-}
 
 export async function POST(request: NextRequest) {
   try {
     const supabase = getSupabase();
+    const contentType = request.headers.get('content-type') || '';
+
+    if (contentType.includes('application/json')) {
+      const body = await request.json();
+      const { init, final, records, filename, totalCount } = body as {
+        init?: boolean;
+        final?: boolean;
+        filename?: string;
+        totalCount?: number;
+        records?: Partial<ReturnGift>[];
+      };
+
+      if (init) {
+        const { error } = await supabase.from('return_gifts').delete().neq('id', 0);
+        if (error) {
+          return NextResponse.json<APIResponse>({ success: false, message: '既存データの削除に失敗しました。' }, { status: 500 });
+        }
+        return NextResponse.json<APIResponse>({ success: true, message: 'initialized' });
+      }
+
+      if (records && records.length > 0) {
+        const { error } = await supabase.from('return_gifts').insert(records);
+        if (error) {
+          return NextResponse.json<APIResponse>({ success: false, message: error.message }, { status: 500 });
+        }
+        return NextResponse.json<APIResponse>({ success: true, message: `${records.length} records inserted` });
+      }
+
+      if (final && filename) {
+        await supabase.from('csv_uploads').insert({ filename, record_count: totalCount || 0, status: 'completed' });
+        return NextResponse.json<APIResponse>({ success: true, message: 'completed' });
+      }
+
+      return NextResponse.json<APIResponse>({ success: false, message: 'Invalid payload' }, { status: 400 });
+    }
+
     const formData = await request.formData();
     const file = formData.get('file') as File;
 

--- a/components/admin/CSVUploader.tsx
+++ b/components/admin/CSVUploader.tsx
@@ -3,7 +3,9 @@
 import { useState, useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Upload, FileText, AlertCircle, CheckCircle } from 'lucide-react';
-import { APIResponse } from '@/types';
+import Papa from 'papaparse';
+import { APIResponse, CSVRowData, ReturnGift } from '@/types';
+import { transformCSVToReturnGift } from '@/lib/transform';
 
 interface CSVUploaderProps {
   onUploadComplete?: (recordCount: number) => void;
@@ -33,33 +35,83 @@ export default function CSVUploader({ onUploadComplete }: CSVUploaderProps) {
     setUploadStatus({ type: null, message: '' });
 
     try {
-      const formData = new FormData();
-      formData.append('file', file);
+      const CHUNK_SIZE = 1000;
+      let recordCount = 0;
+      let batch: Partial<ReturnGift>[] = [];
 
-      const response = await fetch('/api/upload-csv', {
+      // initialize
+      await fetch('/api/upload-csv', {
         method: 'POST',
-        body: formData,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ init: true })
       });
 
-      const result: APIResponse = await response.json();
+      await new Promise<void>((resolve, reject) => {
+        Papa.parse<CSVRowData>(file, {
+          header: true,
+          skipEmptyLines: true,
+          worker: true,
+          step: async ({ data }: Papa.ParseStepResult<CSVRowData>, parser) => {
+            parser.pause();
+            try {
+              if (data.返礼品ID && data.返礼品名) {
+                batch.push(transformCSVToReturnGift(data));
+              }
+              if (batch.length >= CHUNK_SIZE) {
+                const res = await fetch('/api/upload-csv', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ records: batch })
+                });
+                const json: APIResponse = await res.json();
+                if (!json.success) return reject(new Error(json.message));
+                recordCount += batch.length;
+                batch = [];
+              }
+            } catch (e) {
+              return reject(e as Error);
+            } finally {
+              parser.resume();
+            }
+          },
+          complete: async () => {
+            try {
+              if (batch.length > 0) {
+                const res = await fetch('/api/upload-csv', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ records: batch })
+                });
+                const json: APIResponse = await res.json();
+                if (!json.success) return reject(new Error(json.message));
+                recordCount += batch.length;
+                batch = [];
+              }
+              resolve();
+            } catch (e) {
+              reject(e as Error);
+            }
+          },
+          error: (err) => reject(err)
+        });
+      });
 
-      if (result.success) {
-        setUploadStatus({
-          type: 'success',
-          message: result.message,
-          recordCount: result.data?.recordCount
-        });
-        onUploadComplete?.(result.data?.recordCount || 0);
-      } else {
-        setUploadStatus({
-          type: 'error',
-          message: result.message || 'アップロードに失敗しました。'
-        });
-      }
-    } catch (error) {
+      await fetch('/api/upload-csv', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ final: true, filename: file.name, totalCount: recordCount })
+      });
+
+      setUploadStatus({
+        type: 'success',
+        message: `${recordCount}件のデータを正常にアップロードしました。`,
+        recordCount
+      });
+      onUploadComplete?.(recordCount);
+    } catch (error: any) {
       setUploadStatus({
         type: 'error',
-        message: 'ネットワークエラーが発生しました。'
+        message: error.message || 'アップロードに失敗しました。'
       });
     } finally {
       setUploading(false);

--- a/lib/transform.ts
+++ b/lib/transform.ts
@@ -1,0 +1,32 @@
+import { CSVRowData, ReturnGift } from '@/types';
+
+export function transformCSVToReturnGift(csvRow: CSVRowData): Partial<ReturnGift> {
+  return {
+    gift_id: csvRow.返礼品ID,
+    name: csvRow.返礼品名,
+    description: csvRow.返礼品説明 || '',
+    start_date: csvRow.提供開始日時 ? new Date(csvRow.提供開始日時).toISOString() : undefined,
+    end_date: csvRow.提供終了日時 ? new Date(csvRow.提供終了日時).toISOString() : undefined,
+    donation_amount: parseInt(csvRow.寄付金額) || 0,
+    stock_quantity: csvRow.在庫数 ? parseFloat(csvRow.在庫数) : undefined,
+    capacity_weight: csvRow['容量・重さ'] || '',
+    provider_info: csvRow.提供企業情報 || '',
+    shipping_estimate: csvRow.発送目安 || '',
+    notes: csvRow.注意事項 || '',
+    is_public: csvRow.公開フラグ === '1',
+    temp_shipping: csvRow.常温配送対応フラグ === '1',
+    cold_shipping: csvRow.冷蔵配送対応フラグ === '1',
+    frozen_shipping: csvRow.冷凍配送対応フラグ === '1',
+    regular_delivery: csvRow.定期配送対応フラグ === '1',
+    date_specified_delivery: csvRow.日付指定配送対応フラグ === '1',
+    split_delivery: csvRow.分割配送対応フラグ === '1',
+    simple_packaging: csvRow.簡易包装フラグ === '1',
+    noshi_support: csvRow.のし対応フラグ === '1',
+    municipality_code: csvRow.自治体管理番号 || '',
+    expiry_storage: csvRow['賞味期限・保存'] || '',
+    allergens: csvRow.アレルギー || '',
+    allergen_notes: csvRow.アレルギー備考 || '',
+    category: csvRow.カテゴリ || '',
+    linked_service: csvRow.連携サービス || ''
+  };
+}

--- a/scripts/import-csv-from-storage.ts
+++ b/scripts/import-csv-from-storage.ts
@@ -1,37 +1,7 @@
 import { createAdminClient } from '../lib/supabase';
 import Papa from 'papaparse';
-import { CSVRowData, ReturnGift } from '../types';
-
-function transformCSVToReturnGift(csvRow: CSVRowData): Partial<ReturnGift> {
-  return {
-    gift_id: csvRow.返礼品ID,
-    name: csvRow.返礼品名,
-    description: csvRow.返礼品説明 || '',
-    start_date: csvRow.提供開始日時 ? new Date(csvRow.提供開始日時).toISOString() : undefined,
-    end_date: csvRow.提供終了日時 ? new Date(csvRow.提供終了日時).toISOString() : undefined,
-    donation_amount: parseInt(csvRow.寄付金額) || 0,
-    stock_quantity: csvRow.在庫数 ? parseFloat(csvRow.在庫数) : undefined,
-    capacity_weight: csvRow['容量・重さ'] || '',
-    provider_info: csvRow.提供企業情報 || '',
-    shipping_estimate: csvRow.発送目安 || '',
-    notes: csvRow.注意事項 || '',
-    is_public: csvRow.公開フラグ === '1',
-    temp_shipping: csvRow.常温配送対応フラグ === '1',
-    cold_shipping: csvRow.冷蔵配送対応フラグ === '1',
-    frozen_shipping: csvRow.冷凍配送対応フラグ === '1',
-    regular_delivery: csvRow.定期配送対応フラグ === '1',
-    date_specified_delivery: csvRow.日付指定配送対応フラグ === '1',
-    split_delivery: csvRow.分割配送対応フラグ === '1',
-    simple_packaging: csvRow.簡易包装フラグ === '1',
-    noshi_support: csvRow.のし対応フラグ === '1',
-    municipality_code: csvRow.自治体管理番号 || '',
-    expiry_storage: csvRow['賞味期限・保存'] || '',
-    allergens: csvRow.アレルギー || '',
-    allergen_notes: csvRow.アレルギー備考 || '',
-    category: csvRow.カテゴリ || '',
-    linked_service: csvRow.連携サービス || ''
-  };
-}
+import { CSVRowData } from '../types';
+import { transformCSVToReturnGift } from '../lib/transform';
 
 async function main() {
   const bucket = process.argv[2];


### PR DESCRIPTION
## Summary
- extract CSV transform util
- handle JSON chunk uploads in `upload-csv` API
- stream CSV on client and send data in batches
- share transform in storage import script
- add minimal ESLint config

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a0395ee888326a45493aa2c70adaa