### PR TITLE
Improve large CSV upload handling

### DIFF
--- a/app/api/upload-csv/route.ts
+++ b/app/api/upload-csv/route.ts
@@ -7,6 +7,7 @@ import { transformCSVToReturnGift } from '@/lib/transform';
 
 // Allow large CSV uploads (up to 1GB)
 export const runtime = 'nodejs';
+export const maxDuration = 300;
 
 const getSupabase = () =>
   createClient(


### PR DESCRIPTION
## Summary
- adjust upload API to allow long processing time
- simplify CSVUploader to upload file directly to server

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688abcc6a2bc8326a9c349dda93d9426