### PR TITLE
Fix header normalization when parsing CSV files

### DIFF
--- a/app/api/upload-csv/route.ts
+++ b/app/api/upload-csv/route.ts
@@ -79,7 +79,8 @@ export async function POST(request: NextRequest) {
             header: true,
             skipEmptyLines: true,
             dynamicTyping: false,
-            transformHeader: (header: string) => header.trim(),
+            transformHeader: (header: string) =>
+              header.replace(/^\uFEFF/, '').trim(),
           })
         );
 

--- a/components/admin/CSVUploader.tsx
+++ b/components/admin/CSVUploader.tsx
@@ -59,6 +59,8 @@ export default function CSVUploader({ onUploadComplete }: CSVUploaderProps) {
           header: true,
           skipEmptyLines: true,
           dynamicTyping: false,
+          transformHeader: (header: string) =>
+            header.replace(/^\uFEFF/, '').trim(),
           worker: true,
           chunk: async (results, parser) => {
             parser.pause();

--- a/scripts/import-csv-from-storage.ts
+++ b/scripts/import-csv-from-storage.ts
@@ -20,7 +20,13 @@ async function main() {
   }
 
   const text = await file.text();
-  const parseResult = Papa.parse<CSVRowData>(text, { header: true, skipEmptyLines: true, dynamicTyping: false });
+  const parseResult = Papa.parse<CSVRowData>(text, {
+    header: true,
+    skipEmptyLines: true,
+    dynamicTyping: false,
+    transformHeader: (header: string) =>
+      header.replace(/^\uFEFF/, '').trim(),
+  });
 
   if (parseResult.errors.length > 0) {
     throw new Error(parseResult.errors[0].message);


### PR DESCRIPTION
## Summary
- strip BOM when parsing CSV headers from API uploads
- apply the same transform when uploading via the UI
- handle BOMs when importing CSV from storage

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ad6adee048326b318cb05336dde2b