### PR TITLE
Fix recommendation response and upgrade to ChatGPT 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - **フロントエンド**: Next.js 14 (App Router), React, Tailwind CSS
 - **バックエンド**: Next.js API Routes
 - **データベース**: Supabase (PostgreSQL)
-- **AI**: OpenAI GPT-4
+- **AI**: OpenAI ChatGPT 4.1
 - **デプロイ**: Vercel
 - **ファイル処理**: Papa Parse
 

--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -3,16 +3,22 @@ import { createClient } from '@supabase/supabase-js';
 import OpenAI from 'openai';
 import { RecommendationRequest, RecommendationResult, ReturnGift, APIResponse } from '@/types';
 
-const getSupabase = () =>
-  createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-  );
+const getSupabase = () => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error("Supabaseの環境変数が設定されていません");
+  }
+  return createClient(url, key);
+};
 
-const getOpenAI = () =>
-  new OpenAI({
-    apiKey: process.env.OPENAI_API_KEY!,
-  });
+const getOpenAI = () => {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OpenAI APIキーが設定されていません");
+  }
+  return new OpenAI({ apiKey });
+};
 
 // カテゴリマッピング（ユーザー選択 → DB検索用）
 const categoryMapping: Record<string, string[]> = {
@@ -195,7 +201,7 @@ ${index + 1}. ${gift.name}
   try {
     const openai = getOpenAI();
     const completion = await openai.chat.completions.create({
-      model: "gpt-4",
+      model: "gpt-4.1",
       messages: [
         {
           role: "system",


### PR DESCRIPTION
## Summary
- improve environment variable checks in the recommendation API
- set ChatGPT model to `gpt-4.1`
- document the use of ChatGPT 4.1 in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b830061a883269b348ad62c6877f8